### PR TITLE
#22 fixed

### DIFF
--- a/src/app/terms/term-list.component.sass
+++ b/src/app/terms/term-list.component.sass
@@ -28,7 +28,9 @@
   position: absolute
 
 .search-result
-  white-space: pre-line !important
+  white-space: pre-wrap !important
+  overflow-wrap: break-word
+  hyphens: auto
   font-family: Roboto
   font-size: 18px
   font-weight: 700
@@ -39,7 +41,9 @@
   margin-left: 31px
 
 .search-result-detail
-  white-space: pre-line !important
+  white-space: pre-wrap !important
+  overflow-wrap: break-word
+  hyphens: auto
   font-family: Roboto
   font-size: 18px
   font-weight: 400


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5613150/219123516-1eb34eab-d7fb-4a4b-ac17-bba273efdea1.png)
![image](https://user-images.githubusercontent.com/5613150/219123521-75a0429c-0028-4e5f-a298-11d533d363ba.png)

Heyphen ile kelime bölme yapıldı.

Not: sanırım büyük harflerle başlayan kelimelere heyphen konulmaması ile ilgili bir kural var. Kuralı araştırdım bulamadım. Ama defaultta chrome bu şekilde bölüyor. Bug olmak için fazla düzenli.