### PR TITLE
fix/hyphen's were not showing w/o searchTerm

### DIFF
--- a/src/app/terms/term-list.component.html
+++ b/src/app/terms/term-list.component.html
@@ -32,13 +32,13 @@
                 {{term.initial}}
               </span>
               <span class="search-result">
-                <span innerHTML="{{term.translations[selectedSource.isoCode] | highlight : searchTerm.toLocaleLowerCase(selectedSource.isoCode)}}"></span>
+                <span innerHTML="{{ searchTerm ? (term.translations[selectedSource.isoCode] | highlight : searchTerm.toLocaleLowerCase(selectedSource.isoCode)) : (term.translations[selectedSource.isoCode])}}"></span>
               </span>
             </span>
   
             <span matListItemLine class="search-result-detail">
               <span class="spacer"></span>
-              <span innerHTML="{{term.translations[selectedTarget.isoCode] | highlight : searchTerm.toLocaleLowerCase(selectedTarget.isoCode)}}"></span>
+              <span innerHTML="{{ searchTerm ? (term.translations[selectedTarget.isoCode] | highlight : searchTerm.toLocaleLowerCase(selectedTarget.isoCode)) : term.translations[selectedTarget.isoCode]}}"></span>
             </span>
           </div>
         </mat-list-item>


### PR DESCRIPTION
* Prevented keyboard from covering search items and making them unable to be selected.
* Improved highlighting when searchTerm is missing
