### PR TITLE
chore(ci): update lcov-reporter-action to v0.3.1

### DIFF
--- a/.github/workflows/unit-test-run.yml
+++ b/.github/workflows/unit-test-run.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           files: |
             report/test/unit-test.xml
-      - uses: romeovs/lcov-reporter-action@v0.2.16
+      - uses: romeovs/lcov-reporter-action@v0.3.1
         with:
           lcov-file: ./report/coverage/report-lcov/lcov.info
           github-token: ${{ github.token }}


### PR DESCRIPTION
fixes master ci pipeline due to https://github.com/romeovs/lcov-reporter-action/issues/16